### PR TITLE
[ocio] handling of negatives values in log transform

### DIFF
--- a/dev/launchers/Nuke-13.0.9-windows.sh
+++ b/dev/launchers/Nuke-13.0.9-windows.sh
@@ -1,0 +1,14 @@
+# Nuke launcher script for Windows. To use with GitBash.
+
+# go to repo root assuming cwd is directory of this file
+cd ../..
+pwd
+
+NUKE_HOME="/C/Program Files/Nuke13.0v9"
+NUKE_EXE="$NUKE_HOME/Nuke13.0.exe"
+
+export OCIO="./ocio/config.ocio"
+
+NUKE_SCENE_TEST="./dev/scenes/nuke/AgXc.test_pattern.nk"
+
+"$NUKE_EXE" $NUKE_SCENE_TEST

--- a/ocio/config.ocio
+++ b/ocio/config.ocio
@@ -76,11 +76,14 @@ colorspaces:
     from_reference: !<GroupTransform>
       children:
         # the 2 CLDTransform are a hack to clamp negatives
+        # 2nd one has an offset else considered no-op and no clamp applied
         - !<CDLTransform> {power: [2.0, 2.0, 2.0]}
-        # supposed to be the inverse transform, but slight offset else considered identity and not applied
         - !<CDLTransform> {power: [0.500001, 0.500001, 0.500001]}
         - !<MatrixTransform> { matrix: [ 0.842479062253094, 0.0784335999999992, 0.0792237451477643, 0, 0.0423282422610123, 0.878468636469772, 0.0791661274605434, 0, 0.0423756549057051, 0.0784336, 0.879142973793104, 0, 0, 0, 0, 1 ] }
         - !<AllocationTransform> { allocation: lg2, vars: [ -12.47393, 4.026069] }
+        # the 2 CLDTransform are a hack to clamp negatives
+        - !<CDLTransform> {power: [0.500001, 0.500001, 0.500001]}
+        - !<CDLTransform> {power: [2.0, 2.0, 2.0]}
 
   - !<ColorSpace>
     name: 2.2 EOTF Encoding

--- a/ocio/config.ocio
+++ b/ocio/config.ocio
@@ -81,9 +81,6 @@ colorspaces:
         - !<CDLTransform> {power: [0.500001, 0.500001, 0.500001]}
         - !<MatrixTransform> { matrix: [ 0.842479062253094, 0.0784335999999992, 0.0792237451477643, 0, 0.0423282422610123, 0.878468636469772, 0.0791661274605434, 0, 0.0423756549057051, 0.0784336, 0.879142973793104, 0, 0, 0, 0, 1 ] }
         - !<AllocationTransform> { allocation: lg2, vars: [ -12.47393, 4.026069] }
-        # the 2 CLDTransform are a hack to clamp negatives
-        - !<CDLTransform> {power: [0.500001, 0.500001, 0.500001]}
-        - !<CDLTransform> {power: [2.0, 2.0, 2.0]}
 
   - !<ColorSpace>
     name: 2.2 EOTF Encoding

--- a/ocio/config.ocio
+++ b/ocio/config.ocio
@@ -1,4 +1,4 @@
-# version: 0.2.1
+# version: 0.2.2
 ocio_profile_version: 1
 description: |
   AgX config by Troy Sobotka. Modified by Liam Collod with full permissions from

--- a/ocio/config.ocio
+++ b/ocio/config.ocio
@@ -75,10 +75,12 @@ colorspaces:
     allocationvars: [ -12.47393, 4.026069 ]
     from_reference: !<GroupTransform>
       children:
+        # the 2 CLDTransform are a hack to clamp negatives
+        - !<CDLTransform> {power: [2.0, 2.0, 2.0]}
+        # supposed to be the inverse transform, but slight offset else considered identity and not applied
+        - !<CDLTransform> {power: [0.500001, 0.500001, 0.500001]}
         - !<MatrixTransform> { matrix: [ 0.842479062253094, 0.0784335999999992, 0.0792237451477643, 0, 0.0423282422610123, 0.878468636469772, 0.0791661274605434, 0, 0.0423756549057051, 0.0784336, 0.879142973793104, 0, 0, 0, 0, 1 ] }
         - !<AllocationTransform> { allocation: lg2, vars: [ -12.47393, 4.026069] }
-        # hack to clamp to 0-1
-        - !<FileTransform> { src: dummy.spi1d, interpolation: linear }
 
   - !<ColorSpace>
     name: 2.2 EOTF Encoding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "AgXc"
-version = "0.4.1"
+version = "0.4.2"
 description = "Fork of Troy.S AgX, a display rendering transform available via OCIO and more."
 authors = ["Liam Collod <monsieurlixm@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Closes #11

Hey, this PR fix the issues with negatives in the `AgX Log` colorspace.
My initial solution was using a "dummy" LUT, doing nothing, but still clamping between 0 and 1. I actually found it was not working in the pre-log section so I removed it in #10 .

I found another solution using an unintentional behaviour in the `CDLTransform` (documented in the v2 doc), where negatives are clamped when the power is not 1.

So I just slap it pre-log and post-log and goodby negatives.
It is still hacky because I had to use a small offset in the power value to the 2 forward/inverse transform are not considered a no-op, and the clamp is still applied.
This means there is a small unintended difference in the output data that I don't like to have. But I think we could discard that seeing the benefits it brings.

This works on OCIOv1 and OCIOv2 (behaviour was preserved on v2 for v1 config).

# Changes

- `config.ocio`/AgX Log transform chain
- added Nuke 13.0.9 launcher to test config on OCIOv1 (all the version above are v2)